### PR TITLE
rebind Processing.instances when processingInstances is cleared

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -20206,6 +20206,7 @@
     // sketch duplication when page content is dynamically swapped without
     // swapping out processing.js
     processingInstances = [];
+    Processing.instances = processingInstances;
 
     var canvas = document.getElementsByTagName('canvas'),
       filenames;


### PR DESCRIPTION
this should ensure that Processing.instances always reflects the internal instance list
