### PR TITLE
Processing.js fixed when running inside a firefox extension

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -2070,7 +2070,7 @@
       curElement = typeof aCanvas === "string" ? document.getElementById(aCanvas) : aCanvas;
     }
 
-    if (!(curElement instanceof HTMLCanvasElement)) {
+    if (!('getContext' in curElement)) {
       throw("called Processing constructor without passing canvas element reference or id.");
     }
 


### PR DESCRIPTION
I've tried to run processing.js inside a firefox extension that we were doing.
We found a few erros and we fixed it.
They happened because of the implementation of XULDocument that replaces the actual document.
