### PR TITLE
Bug 1923 - Ignore image type in loadImage

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -15077,10 +15077,8 @@
     * @see background
     */
     p.loadImage = function(file, type, callback) {
-      // if type is specified add it with a . to file to make the filename
-      if (type) {
-        file = file + "." + type;
-      }
+      // if type is specified, we just ignore it
+
       var pimg;
       // if image is in the preloader cache return a new PImage
       if (curSketch.imageCache.images[file]) {


### PR DESCRIPTION
I have no idea why this code was doing what it was doing. `Image` doesn't care what type of image it is, so long as it can be loaded.
