### PR TITLE
fix bug 1935

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -430,9 +430,6 @@
   * @param {Object} obj          The object to be iterated.
   */
   var ObjectIterator = function(obj) {
-    if (obj.iterator instanceof Function) {
-      return obj.iterator();
-    }
     if (obj instanceof Array) {
       // iterate through array items
       var index = -1;
@@ -442,6 +439,8 @@
       this.next = function() {
         return obj[index];
       };
+    } else if (obj.iterator instanceof Function) {
+      return obj.iterator();
     } else {
       throw "Unable to iterate: " + obj;
     }


### PR DESCRIPTION
fix for bug 1935: https://processing-js.lighthouseapp.com/projects/41284-processingjs/tickets/1935-the-for-each-loop-over-arrays-doesnt-work-on-firefox-17#ticket-1935-2

Apparently FF now has an undocumented proto method called "iterator" for Array objects. That was the cause of the bug. No evidence of this iterator method was to be found on MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array
