### PR TITLE
Fixing 'this' to refer to the sketch in main methods.

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -19371,7 +19371,8 @@
       };
       var body = this.params.prependMethodArgs(this.body.toString());
       var result = "function " + this.name + this.params + " " + body + "\n" +
-        "$p." + this.name + " = " + this.name + ";";
+        "$p." + this.name + " = " + this.name + ";\n" +
+        this.name + " = " + this.name + ".bind($p);";
       replaceContext = oldContext;
       return result;
     };


### PR DESCRIPTION
In top level methods, `this` does not work correctly
IE

``` java
void setup() {
  println("running test");
  test();
  test = test.bind($p);
  test();
}

void test() {
  try { 
    this.printout(); 
  } catch(Exception e) {
    e.printStackTrace();
  }
}

void printout() {
  println("hello!");
}
```

Currently throws an exception the first time, but not the second time.
If we add `method = method.bind($p)` after every function, it appears to work correctly. However, variables still aren't playing nice. Is this something anyone else has issues with? Will this cause issues in other ways? 
