### PR TITLE
Fixed bug where implicit semicolon insertion was messing up returns.

### DIFF
--- a/src/Parser/Parser.js
+++ b/src/Parser/Parser.js
@@ -223,6 +223,9 @@ module.exports = function setupParser(Processing, options) {
     // convert dollar sign to character code
     codeWoStrings = codeWoStrings.replace(/\$/g, "__x0024");
 
+    // Remove newlines after return statements
+    codeWoStrings = codeWoStrings.replace(/return\s*[\n\r]+/g, "return ");
+
     // removes generics
     var genericsWereRemoved;
     var codeWoGenerics = codeWoStrings;

--- a/test/unit/ticket2052.pde
+++ b/test/unit/ticket2052.pde
@@ -1,0 +1,18 @@
+void return1() {
+	return
+		1 == 1;
+}
+
+void return2() {
+	return
+
+		1 == 1;
+}
+
+void return3() {
+	return 1 == 1;
+}
+
+_checkEqual(return1(), true);
+_checkEqual(return2(), true);
+_checkEqual(return3(), true);


### PR DESCRIPTION
Bug reported here: https://processing-js.lighthouseapp.com/projects/41284/tickets/2052-return-statements-not-always-parsed-correctly#ticket-2052-1

It was failing before because of JavaScript's implicit semi-colon insertion mechanism.
