### PR TITLE
Fixes #2051: .charAt now returns a Char, not a string.

### DIFF
--- a/src/Parser/Parser.js
+++ b/src/Parser/Parser.js
@@ -193,6 +193,9 @@ module.exports = function setupParser(Processing, options) {
     // remove carriage returns "\r"
     var codeWoExtraCr = code.replace(/\r\n?|\n\r/g, "\n");
 
+    // replace instances of .charAt with ._processingCharAt
+    codeWoExtraCr = codeWoExtraCr.replace(/"\.charAt\(/g, "\"._processingCharAt(");
+
     // masks strings and regexs with "'5'", where 5 is the index in an array containing all strings and regexs
     // also removes all comments
     var strings = [];

--- a/src/Processing.js
+++ b/src/Processing.js
@@ -4500,6 +4500,16 @@
     p.match = function(str, regexp) {
       return str.match(regexp);
     };
+    /**
+     * Adds a .charAtProcessing() which is called instead of .charAt and returns
+     * a Char instead of a string - see bug report #2051.
+     *
+     * @param {int} index the index of the character to get
+     */
+    String.prototype._processingCharAt = function(index) {
+	    return new Char(this.charAt(index));
+    };
+
 
     ////////////////////////////////////////////////////////////////////////////
     // Other java specific functions

--- a/test/unit/ticket2051.pde
+++ b/test/unit/ticket2051.pde
@@ -1,0 +1,3 @@
+// "TEST".charAt(0) == 'T'; // true in processing, false in processing.js
+
+_checkEqual("TEST".charAt(0), 'T');


### PR DESCRIPTION
https://processing-js.lighthouseapp.com/projects/41284-processingjs/tickets/2051-charat-issue

I don't like this fix, it feels too hacky to me. I can't think of a better way to do it, though (and a function called .charAt really should return a Char).
