### PR TITLE
Fix exception when indexing arguments

### DIFF
--- a/src/Processing.js
+++ b/src/Processing.js
@@ -6311,7 +6311,7 @@
      * @see #colorMode()
      */
     DrawingShared.prototype.fill = function() {
-      var color = p.color(arguments[0], arguments[1], arguments[2], arguments[3]);
+      var color = p.color.apply(this, arguments);
       if(color === currentFillColor && doFill) {
         return;
       }
@@ -6381,7 +6381,7 @@
      * @see #colorMode()
      */
     DrawingShared.prototype.stroke = function() {
-      var color = p.color(arguments[0], arguments[1], arguments[2], arguments[3]);
+      var color = p.color.apply(this, arguments);
       if(color === currentStrokeColor && doStroke) {
         return;
       }


### PR DESCRIPTION
When calling "fill(255, 255, 255)" with no alpha argument,
running on recent versions of the Javascriptcore engine
(e.g. in the Epiphany browser with WebKit 2.2.1),
Processing tries to access arguments[3] which throws an
exception. Apparently earlier versions of Javascriptcore
allowed this.
