### PR TITLE
Add explicit size of 0x0 to PJS auto-generated span.

### DIFF
--- a/src/Objects/PFont.js
+++ b/src/Objects/PFont.js
@@ -290,7 +290,7 @@ module.exports = function(options,undef) {
 
       // set up the template element
       var element = document.createElement("span");
-      element.style.cssText = 'position: absolute; width: 0px; height: 0px; top: 0; left: 0; opacity: 0; font-family: "PjsEmptyFont", fantasy;';
+      element.style.cssText = 'position: absolute; width: 0px; height: 0px; display: none; top: 0; left: 0; opacity: 0; font-family: "PjsEmptyFont", fantasy;';
       element.innerHTML = "AAAAAAAA";
       document.body.appendChild(element);
       this.template = element;


### PR DESCRIPTION
This seemingly minor change should prevent Processing.js from blowing sites out of proportion in certain situations, as in [this google groups thread](https://groups.google.com/forum/#!topic/processingjs/yqzyWCwZeU4).
