### PR TITLE
Don't round when renderSmooth is true (for lines, points, and rectangles)

### DIFF
--- a/src/Processing.js
+++ b/src/Processing.js
@@ -6543,9 +6543,10 @@
       if (!doStroke) {
         return;
       }
-
-      x = Math.round(x);
-      y = Math.round(y);
+      if (!renderSmooth) {
+        x = Math.round(x);
+        y = Math.round(y);
+      }
       curContext.fillStyle = p.color.toString(currentStrokeColor);
       isFillDirty = true;
       // Draw a circle for any point larger than 1px
@@ -8091,10 +8092,13 @@
       if (!doStroke) {
         return;
       }
-      x1 = Math.round(x1);
-      x2 = Math.round(x2);
-      y1 = Math.round(y1);
-      y2 = Math.round(y2);
+      if (!renderSmooth) {
+        x1 = Math.round(x1);
+        x2 = Math.round(x2);
+        y1 = Math.round(y1);
+        y2 = Math.round(y2);
+      }
+
       // A line is only defined if it has different start and end coordinates.
       // If they are the same, we call point instead.
       if (x1 === x2 && y1 === y2) {
@@ -8450,10 +8454,12 @@
         y -= height / 2;
       }
 
-      x = Math.round(x);
-      y = Math.round(y);
-      width = Math.round(width);
-      height = Math.round(height);
+      if (!renderSmooth) {
+        x = Math.round(x);
+        y = Math.round(y);
+        width = Math.round(width);
+        height = Math.round(height);
+      }
       if (tl !== undef) {
         roundedRect$2d(x, y, width, height, tl, tr, br, bl);
         return;


### PR DESCRIPTION
`renderSmooth` is false by default so users will have to call `smooth()` to get the new behaviour.

before:
![screen shot 2014-10-13 at 11 10 45 pm](https://cloud.githubusercontent.com/assets/1044413/4640135/af12987e-541a-11e4-9bf6-c7635a182085.png)

after:
![screen shot 2014-10-14 at 9 21 12 pm](https://cloud.githubusercontent.com/assets/1044413/4640136/b48a5c2e-541a-11e4-9fd1-412039dbcf42.png)
