### PR TITLE
lerpColor: round float to int instead of truncate.

### DIFF
--- a/src/Processing.js
+++ b/src/Processing.js
@@ -3235,7 +3235,7 @@
         b = p.lerp(hsb1[2], hsb2[2], amt);
         rgb = p.color.toRGB(h, s, b);
         // ... and for Alpha-range
-        a = p.lerp(a1, a2, amt) * colorModeA;
+        a = (p.lerp(a1, a2, amt) * colorModeA + 0.5) | 0;
 
         return (a << 24) & PConstants.ALPHA_MASK |
                (rgb[0] << 16) & PConstants.RED_MASK |
@@ -3256,10 +3256,10 @@
       a2 = ((colorBits2 & PConstants.ALPHA_MASK) >>> 24) / colorModeA;
 
       // Return lerp value for each channel, INT for color, Float for Alpha-range
-      r = p.lerp(r1, r2, amt) | 0;
-      g = p.lerp(g1, g2, amt) | 0;
-      b = p.lerp(b1, b2, amt) | 0;
-      a = p.lerp(a1, a2, amt) * colorModeA;
+      r = (p.lerp(r1, r2, amt) + 0.5) | 0;
+      g = (p.lerp(g1, g2, amt) + 0.5) | 0;
+      b = (p.lerp(b1, b2, amt) + 0.5) | 0;
+      a = (p.lerp(a1, a2, amt) * colorModeA + 0.5) | 0;
 
       return (a << 24) & PConstants.ALPHA_MASK |
              (r << 16) & PConstants.RED_MASK |

--- a/test/unit/lerp.pde
+++ b/test/unit/lerp.pde
@@ -24,8 +24,8 @@ to = color(250, 30);
 interA = lerpColor(from, to, .33);
 interB = lerpColor(from, to, .66);
 
-_checkEqual(color.toArray(interA), [89, 89, 89, 143]);
-_checkEqual(color.toArray(interB), [168, 168, 168, 87]);
+_checkEqual(color.toArray(interA), [89, 89, 89, 144]);
+_checkEqual(color.toArray(interB), [168, 168, 168, 88]);
 
 
 // RGB
@@ -35,8 +35,8 @@ to = color(0, 102, 153);
 interA = lerpColor(from, to, .33);
 interB = lerpColor(from, to, .66);
 
-_checkEqual(color.toArray(interA), [136, 102, 50, 255]);
-_checkEqual(color.toArray(interB), [69, 102, 100, 255]);
+_checkEqual(color.toArray(interA), [137, 102, 50, 255]);
+_checkEqual(color.toArray(interB), [69, 102, 101, 255]);
 
 
 // RGB with alpha
@@ -46,8 +46,8 @@ to = color(0, 102, 153, 72);
 interA = lerpColor(from, to, .33);
 interB = lerpColor(from, to, .66);
 
-_checkEqual(color.toArray(interA), [136, 102, 50, 144]);
-_checkEqual(color.toArray(interB), [69, 102, 100, 108]);
+_checkEqual(color.toArray(interA), [137, 102, 50, 144]);
+_checkEqual(color.toArray(interB), [69, 102, 101, 109]);
 
 
 // HSB
@@ -72,5 +72,5 @@ interB = lerpColor(from, to, .66);
 _checkEqual(color.toArray(interA), [52, 73, 65, 106]);
 // p5 estimates a little bit different values
 // _checkEqual(color.toArray(interB), [54, 58, 65, 67]);
-_checkEqual(color.toArray(interB), [55, 60, 65, 67]);
+_checkEqual(color.toArray(interB), [55, 60, 65, 68]);
 


### PR DESCRIPTION
It is done to match latest processing change: https://github.com/processing/processing/pull/2813
The lerp.pde test is updated with values computed with latest processing.