### PR TITLE
XML toString fix for null textcontent/CData

### DIFF
--- a/src/Objects/XMLElement.js
+++ b/src/Objects/XMLElement.js
@@ -757,11 +757,11 @@ module.exports = function(options, undef) {
     toString: function() {
       // shortcut for text and cdata nodes
       if (this.type === "TEXT") {
-        return this.content;
+        return this.content || "";
       }
 
       if (this.type === "CDATA") {
-        return this.cdata;
+        return this.cdata || "";
       }
 
       // real XMLElements
@@ -777,7 +777,7 @@ module.exports = function(options, undef) {
 
       // serialize all children to XML string
       if (this.children.length === 0) {
-        if (this.content==="") {
+        if (this.content==="" || this.content===null) {
           xmlstring += "/>";
         } else {
           xmlstring += ">" + this.content + "</"+tagstring+">";

--- a/src/Objects/XMLElement.js
+++ b/src/Objects/XMLElement.js
@@ -777,7 +777,7 @@ module.exports = function(options, undef) {
 
       // serialize all children to XML string
       if (this.children.length === 0) {
-        if (this.content==="" || this.content==null) {
+        if (this.content === "" || this.content == null) {
           xmlstring += "/>";
         } else {
           xmlstring += ">" + this.content + "</"+tagstring+">";

--- a/src/Objects/XMLElement.js
+++ b/src/Objects/XMLElement.js
@@ -777,7 +777,7 @@ module.exports = function(options, undef) {
 
       // serialize all children to XML string
       if (this.children.length === 0) {
-        if (this.content==="" || this.content===null) {
+        if (this.content==="" || this.content==null) {
           xmlstring += "/>";
         } else {
           xmlstring += ">" + this.content + "</"+tagstring+">";

--- a/test/unit/XMLElement/P52.0/XMLtoString.pde
+++ b/test/unit/XMLElement/P52.0/XMLtoString.pde
@@ -1,0 +1,5 @@
+String xmlstring = "<root><a></a><b></b></root>";
+XMLElement e = XMLElement.parse(xmlstring);
+String id = e.toString();
+String check = "<root><a/><b/></root>";
+_checkEqual(id,check);


### PR DESCRIPTION
plus unit test - note that it appears there is a bug in `jsdom` (or the version currently used for building Pjs) that prevents testing against `<root><a/><b/><root>` as input. For some reason, this is treated as unterminated elements `a/` and `b/`...