### PR TITLE
Fixes #168

### DIFF
--- a/src/Objects/PVector.js
+++ b/src/Objects/PVector.js
@@ -51,7 +51,7 @@ module.exports = function(options, undef) {
   };
 
   PVector.angleBetween = function(v1, v2) {
-    return Math.acos(v1.dot(v2) / (v1.mag() * v2.mag()));
+    return Math.acos(v1.dot(v2) / Math.sqrt(v1.magSq() * v2.magSq()));
   };
 
   PVector.lerp = function(v1, v2, amt) {


### PR DESCRIPTION
As mentionned in issue 168, PVector.angleBetween() sometimes returns NaN when given two identical vectors. I think the problem comes from rounding issues between multiplying two (identical) square roots (the results of v1.mag() and v2.mag()). This change should fix this issue.