### PR TITLE
adding and subtracting for 2D vectors

### DIFF
--- a/src/Objects/PVector.js
+++ b/src/Objects/PVector.js
@@ -106,6 +106,10 @@ module.exports = function(options, undef) {
         this.x += v.x;
         this.y += v.y;
         this.z += v.z;
+      } else if (arguments.length === 2) {
+        // 2D Vector
+        this.x += v;
+        this.y += y;
       } else {
         this.x += v;
         this.y += y;
@@ -117,6 +121,10 @@ module.exports = function(options, undef) {
         this.x -= v.x;
         this.y -= v.y;
         this.z -= v.z;
+      } else if (arguments.length === 2) {
+        // 2D Vector
+        this.x -= v;
+        this.y -= y;
       } else {
         this.x -= v;
         this.y -= y;
@@ -234,4 +242,3 @@ module.exports = function(options, undef) {
 
   return PVector;
 };
-


### PR DESCRIPTION
Lets 2D vectors add and subtract without worrying about the z-axis.  Currently, the behavior is as follows, which is a little confusing.

    var v = new PVector(3, 4);
    v.add(2, 4); // v is now (5, 8, NaN), and this happens without any errors
    v.limit(5); // limit, and other methods that operate on the vector, now don't work


Although the [docs](http://processingjs.org/reference/PVector/) only suggest support for 3D adding and subtracting, since PVectors can be 2D as well, it'd be nice to handle this as well.  Currently, it will do `v.z += undefined`, which causes errors for most of the other PVector methods, such as `limit`.  If you had defined a 2D vector, you might expect to be able to perform operations on it as a 2D vector without considering the implicit z-axis.

This came up through an [issue](https://github.com/Khan/live-editor/issues/379) on another project.