### PR TITLE
Update Math.js to fix Issue #244

### DIFF
--- a/src/P5Functions/Math.js
+++ b/src/P5Functions/Math.js
@@ -433,7 +433,14 @@ module.exports = function withMath(p, undef) {
       return internalRandomGenerator() * arguments[0];
     }
     var aMin = arguments[0], aMax = arguments[1];
-    return internalRandomGenerator() * (aMax - aMin) + aMin;
+    while (true) {
+      var ir = internalRandomGenerator();
+      var result = ir * (aMax - aMin) + aMin;
+      if (result !== aMax || result === aMin) {
+        return result;
+      }
+      // assertion: ir is never less than 0.5
+    }
   };
 
   // Pseudo-random generator

--- a/src/P5Functions/Math.js
+++ b/src/P5Functions/Math.js
@@ -433,14 +433,18 @@ module.exports = function withMath(p, undef) {
       return internalRandomGenerator() * arguments[0];
     }
     var aMin = arguments[0], aMax = arguments[1];
-    while (true) {
+    if (aMin === aMax) {
+      return aMin;
+    }
+    while (var i = 0; i < 100; i++) {
       var ir = internalRandomGenerator();
       var result = ir * (aMax - aMin) + aMin;
-      if (result !== aMax || result === aMin) {
+      if (result !== aMax) {
         return result;
       }
       // assertion: ir is never less than 0.5
     }
+    return aMin;
   };
 
   // Pseudo-random generator

--- a/src/P5Functions/Math.js
+++ b/src/P5Functions/Math.js
@@ -436,7 +436,7 @@ module.exports = function withMath(p, undef) {
     if (aMin === aMax) {
       return aMin;
     }
-    while (var i = 0; i < 100; i++) {
+    for (var i = 0; i < 100; i++) {
       var ir = internalRandomGenerator();
       var result = ir * (aMax - aMin) + aMin;
       if (result !== aMax) {

--- a/test/unit/random.pde
+++ b/test/unit/random.pde
@@ -59,13 +59,13 @@ for(int i=0;i<attempts;++i) {
   if(sample < minSample || sample >= maxSample) _checkTrue(false); // bad random with two arg
 }
 
-var r,
-    c = 512,
+double r,
+    c = 512.0,
     d = 0.000000001,
     a = c - d,
-    b = c,
-    failed = false;
-for (var i=0; i<100000; i++) {
+    b = c;
+boolean failed = false;
+for (int i=0; i<100000; i++) {
   r = random(a, b);
   if (r >= b || r < a) {
     failed = true;

--- a/test/unit/random.pde
+++ b/test/unit/random.pde
@@ -58,3 +58,19 @@ for(int i=0;i<attempts;++i) {
   var sample = random(minSample, maxSample);
   if(sample < minSample || sample >= maxSample) _checkTrue(false); // bad random with two arg
 }
+
+var r,
+    c = 512,
+    d = 0.000000001,
+    a = c - d,
+    b = c,
+    failed = false;
+for (var i=0; i<100000; i++) {
+  r = random(a, b);
+  if (r >= b || r < a) {
+    failed = true;
+    break;
+  }
+}
+// at this point `failed` reflects whether or not the previous run failed even once.
+_checkFalse(failed);


### PR DESCRIPTION
Added a retry loop to random() so that it will never return its second argument (the "upper" bound) except in the truly degenerate case where it equals its first argument (the "lower" bound).  By avoiding > and < , the fix continues to support callers who disregard the notions of "lower" and "upper", e.g. random(10.2, -5).  The worst case probability of having to retry a new value of ir is 50%.