### PR TITLE
Fix issue #271 - hue value -1 causes crash

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -12613,6 +12613,9 @@ module.exports = function setupParser(Processing, options) {
       s = (s > colorModeY) ? colorModeY : s;
       b = (b > colorModeZ) ? colorModeZ : b;
 
+      // Limit values smaller than range
+      h  = (h < 0) ? 0 : h;
+
       h = (h / colorModeX) * 360;
       s = (s / colorModeY) * 100;
       b = (b / colorModeZ) * 100;
@@ -12640,6 +12643,8 @@ module.exports = function setupParser(Processing, options) {
         return [t, p, br];
       case 5:
         return [br, p, q];
+      default:
+        Processing.debug("Unexpectedly hit default case in toRGB function.");
       }
     };
 

--- a/processing.js
+++ b/processing.js
@@ -12613,9 +12613,6 @@ module.exports = function setupParser(Processing, options) {
       s = (s > colorModeY) ? colorModeY : s;
       b = (b > colorModeZ) ? colorModeZ : b;
 
-      // Limit values smaller than range
-      h  = (h < 0) ? 0 : h;
-
       h = (h / colorModeX) * 360;
       s = (s / colorModeY) * 100;
       b = (b / colorModeZ) * 100;
@@ -12643,8 +12640,6 @@ module.exports = function setupParser(Processing, options) {
         return [t, p, br];
       case 5:
         return [br, p, q];
-      default:
-        Processing.debug("Unexpectedly hit default case in toRGB function.");
       }
     };
 

--- a/src/Processing.js
+++ b/src/Processing.js
@@ -3030,7 +3030,7 @@
       b = (b > colorModeZ) ? colorModeZ : b;
 
       // Limit values smaller than range
-      b = (h < 0) ? 0 : h;
+      h = (h < 0) ? 0 : h;
 
       h = (h / colorModeX) * 360;
       s = (s / colorModeY) * 100;

--- a/src/Processing.js
+++ b/src/Processing.js
@@ -3029,6 +3029,9 @@
       s = (s > colorModeY) ? colorModeY : s;
       b = (b > colorModeZ) ? colorModeZ : b;
 
+      // Limit values smaller than range
+      b = (h < 0) ? 0 : h;
+
       h = (h / colorModeX) * 360;
       s = (s / colorModeY) * 100;
       b = (b / colorModeZ) * 100;
@@ -3056,6 +3059,8 @@
         return [t, p, br];
       case 5:
         return [br, p, q];
+      default:
+        Processing.debug("Unexpectedly hit default case in toRGB function.");
       }
     };
 

--- a/test/unit/color.pde
+++ b/test/unit/color.pde
@@ -185,6 +185,12 @@ colorMode(RGB, 100);
 color h1 = color(100);
 _checkEqual([hue(h1), saturation(h1), brightness(h1)], [0, 0, 100]);
 
+// Test HSB robustness to negative values
+colorMode(HSB);
+color r1 = color(-1,100,100);
+color r2 = color(0,100,100);
+_checkEqual(r1, r2);
+
 // Test HSB color
 colorMode(RGB, 255);
 color c1 = color(204, 153, 0);


### PR DESCRIPTION
Hue should be in range 0-255. Processing behaviour when given a hue value below '0' appears to be to use '0'. To replicate that behaviour and fix this issue we should force the hue value to 0 when it is a negative value.

The specific error the user saw was caused by switching on '-1' (the value of `Math.floor(hue / 60)` when h is -1) in function `toRGB`. As there is no case for '-1', the function didn't return anything. The function `color` then sets `r = rgb[0];`, but rgb is undefined, hence the error "Cannot read property '0' of undefined". 
To provide better diagnostics in future I've added a default case to the switch, this includes a debugging statement indicating that this case is unexpected.

Unit test confirms that negative hue value is treated as '0'.

Fixes #271 